### PR TITLE
Add lifetimes and use references

### DIFF
--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -18,16 +18,16 @@ fn resolve_env_key(key: &str) -> String {
 	};
 }
 
-pub struct Encryption {
-	pub config: ConfigFile,
+pub struct Encryption<'a> {
+	pub config: &'a ConfigFile,
 }
 
-impl Encryption {
-	pub fn encrypt_configuration(&self, new_config: ConfigFile) -> Result<ConfigFile, &'static str> {
+impl Encryption<'_> {
+	pub fn encrypt_configuration(&self, new_config: &ConfigFile) -> Result<ConfigFile, &'static str> {
 		let mut encrypted_configuration: HashMap<String, String> = HashMap::new();
 
 		let new_encrypter = Encryption {
-			config: new_config.clone(),
+			config: new_config,
 		};
 
 		for (key, value) in new_config.configuration.iter() {

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -53,7 +53,7 @@ impl Encryption<'_> {
 
 		Ok(ConfigFile {
 			configuration: encrypted_configuration,
-			keys: new_config.keys,
+			keys: new_config.keys.clone(),
 		})
 	}
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,9 @@ enum Opt {
 }
 
 fn main() {
-    sodiumoxide::init().expect("Was not able to initialize Libsodium.");
+    if sodiumoxide::init().is_err() {
+        return println!("{}", String::from("Was not able to initialize Sodium. Verify your installation of Scoob and try again.").red().bold());
+    }
 
     let cli = Opt::from_args();
 

--- a/src/modify.rs
+++ b/src/modify.rs
@@ -38,7 +38,7 @@ pub fn modify(cmd: &Modify) -> Result<(), &'static str> {
 
 	let original_config = Config::get_config(&cmd.file);
 	let encryption = Encryption {
-		config: original_config.clone(),
+		config: &original_config,
 	};
 
 	let temp_file_contents = match mode {

--- a/src/modify.rs
+++ b/src/modify.rs
@@ -53,7 +53,7 @@ pub fn modify(cmd: &Modify) -> Result<(), &'static str> {
 
 	let new_config: ConfigFile = serde_yaml::from_str(&contents.unwrap()).unwrap();
 
-	let encrypted_config = encryption.encrypt_configuration(new_config)?;
+	let encrypted_config = encryption.encrypt_configuration(&new_config)?;
 
 	std::fs::write(&cmd.file, serde_yaml::to_string(&encrypted_config).unwrap()).unwrap();
 

--- a/src/start.rs
+++ b/src/start.rs
@@ -23,7 +23,7 @@ pub fn start(cmd: &Start) -> Result<i32, &'static str> {
 	let mut command = Command::new(first_command.expect("Missing command."));
 
 	let encryption = Encryption {
-		config: config.clone(),
+		config: &config,
 	};
 
 	for (key, value) in config.configuration.iter() {


### PR DESCRIPTION
@Emily This is my attempt to learn rust a little better. I think that using lifetimes here + a reference is better because it avoids cloning the config a bunch.