### PR TITLE
Rename `modify` to `manage`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,31 +7,38 @@ jobs:
     name: Rust project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout Repo
+        uses: actions/checkout@v2
 
-      - uses: actions-rs/toolchain@v1
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@v1
+      - name: Cache Rust Build
+        uses: Swatinem/rust-cache@v1
 
-      - uses: actions-rs/cargo@v1
+      - name: Build Project
+        uses: actions-rs/cargo@v1
         with:
           command: build
           args: --locked --release
 
-      - uses: actions-rs/cargo@v1
+      - name: Run Tests
+        uses: actions-rs/cargo@v1
         with:
           command: test
 
-      - uses: actions-rs/cargo@v1
+      - name: Check Formatting
+        uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
 
-      - uses: actions-rs/cargo@v1
+      - name: Lint
+        uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: -- -D warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,13 +25,19 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
     steps:
-      - name: Checkout code
+      - name: Checkout Repo
         uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
+
+      - name: Cache Rust Build
+        uses: Swatinem/rust-cache@v1
+
+      - name: Build Project
+        uses: actions-rs/cargo@v1
         with:
           use-cross: true
           command: build
@@ -68,7 +74,7 @@ jobs:
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
 
-      - name: Dispatch to repository
+      - name: Start release job on homebrew repository
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,6 @@ colored = "2"
 [profile.release]
 opt-level = 'z'
 lto = true
+codegen-units = 1
+incremental = true
 panic = 'abort'

--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@ cargo install scoob --locked
 First, you'll want to create a secrets file:
 
 ```bash
-scoob modify --create ./secrets/dev.yml
+scoob manage ./secrets/dev.yml
 ```
 
 This will open your editor with an example Scoob configuration file. A pair of public and secret keys will auto-generated and provided in the file. Make sure you don't commit these into your repository, and instead replace them with values provided dynamically via environment variables. When you close your editor, all of the values under `configuration:` will be encrypted, and the file will be written to disk.
 
-At a later point, you can add additional secrets by running the following command:
+At a later point, you can add additional secrets by running the same command:
 
 ```bash
-scoob modify --edit ./secrets/dev.yml
+scoob manage ./secrets/dev.yml
 ```
 
 We recommend creating a separate secrets file for development and production. This way, you can keep your production keys separate.

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,35 +13,31 @@ pub struct EncryptionKey {
 }
 
 #[derive(Default, Serialize, Deserialize, Clone, Debug)]
-pub struct ConfigFile {
+pub struct Config {
     pub configuration: HashMap<String, String>,
     pub keys: HashMap<String, EncryptionKey>,
 }
 
-impl ConfigFile {
-    pub fn with_placeholders(&self) -> ConfigFile {
+impl Config {
+    pub fn with_placeholders(&self) -> Config {
         let mut placeholder_configuration: HashMap<String, String> = HashMap::new();
 
         for key in self.configuration.keys() {
             placeholder_configuration.insert(key.to_string(), "<encrypted>".to_string());
         }
 
-        ConfigFile {
+        Config {
             configuration: placeholder_configuration,
             keys: self.keys.clone(),
         }
     }
-}
 
-pub struct Config {}
-
-impl Config {
     pub fn exists(path: &Path) -> bool {
         let result = std::fs::read_to_string(path);
         result.is_ok()
     }
 
-    pub fn get(path: &Path) -> ConfigFile {
+    pub fn get(path: &Path) -> Config {
         let result = std::fs::read_to_string(path);
         match result {
             Ok(content) => {
@@ -52,7 +48,7 @@ impl Config {
         }
     }
 
-    pub fn default() -> ConfigFile {
+    pub fn default() -> Config {
         let (public_key, secret_key) = gen_keypair();
 
         let mut default_config: HashMap<String, String> = HashMap::new();
@@ -71,7 +67,7 @@ impl Config {
             },
         );
 
-        ConfigFile {
+        Config {
             configuration: default_config,
             keys: default_keys,
         }

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -1,5 +1,4 @@
-use crate::ConfigFile;
-use crate::EncryptionKey;
+use crate::{EncryptionKey, Config};
 use data_encoding::BASE64;
 use sodiumoxide::crypto::box_::*;
 use sodiumoxide::crypto::sealedbox;
@@ -19,14 +18,14 @@ fn resolve_env_key(key: &str) -> String {
 }
 
 pub struct Encryption<'a> {
-    pub config: &'a ConfigFile,
+    pub config: &'a Config,
 }
 
 impl Encryption<'_> {
     pub fn encrypt_configuration(
         &self,
-        new_config: &ConfigFile,
-    ) -> Result<ConfigFile, &'static str> {
+        new_config: &Config,
+    ) -> Result<Config, &'static str> {
         let mut encrypted_configuration: HashMap<String, String> = HashMap::new();
 
         let new_encrypter = Encryption { config: new_config };
@@ -53,7 +52,7 @@ impl Encryption<'_> {
             };
         }
 
-        Ok(ConfigFile {
+        Ok(Config {
             configuration: encrypted_configuration,
             keys: new_config.keys.clone(),
         })

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -1,4 +1,4 @@
-use crate::{EncryptionKey, Config};
+use crate::{Config, EncryptionKey};
 use data_encoding::BASE64;
 use sodiumoxide::crypto::box_::*;
 use sodiumoxide::crypto::sealedbox;
@@ -22,10 +22,7 @@ pub struct Encryption<'a> {
 }
 
 impl Encryption<'_> {
-    pub fn encrypt_configuration(
-        &self,
-        new_config: &Config,
-    ) -> Result<Config, &'static str> {
+    pub fn encrypt_configuration(&self, new_config: &Config) -> Result<Config, &'static str> {
         let mut encrypted_configuration: HashMap<String, String> = HashMap::new();
 
         let new_encrypter = Encryption { config: new_config };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,56 +1,26 @@
 mod config;
 mod encryption;
-mod modify;
+mod manage;
 mod start;
 
 use crate::config::*;
 use crate::encryption::*;
-use crate::modify::*;
+use crate::manage::*;
 use crate::start::*;
 use colored::Colorize;
 use std::alloc::System;
-use std::path::PathBuf;
 use structopt::StructOpt;
 
 #[global_allocator]
 static A: System = System;
 
-#[derive(Debug, PartialEq, StructOpt)]
-pub enum SubCommand {
-    #[structopt(external_subcommand)]
-    Other(Vec<String>),
-}
-
-#[derive(Debug, StructOpt)]
-pub struct Modify {
-    /// Edit the provided configuration file
-    #[structopt(short, long)]
-    edit: bool,
-    /// Create the configuration file
-    #[structopt(short, long)]
-    create: bool,
-    /// Path to the scoob configuration file
-    #[structopt(parse(from_os_str))]
-    file: PathBuf,
-}
-
-#[derive(Debug, StructOpt)]
-pub struct Start {
-    /// Path to the scoob configuration file
-    #[structopt(parse(from_os_str))]
-    file: PathBuf,
-    /// The sub-command that you wish to run
-    #[structopt(subcommand)]
-    sub_command: SubCommand,
-}
-
 #[derive(Debug, StructOpt)]
 #[structopt(name = "scoob", about = "A secrets management tool.")]
 enum Opt {
-    /// Open a scoob configuration file for modification
-    Modify(Modify),
+    /// Manage a scoob configuration file
+    Manage(Manage),
 
-    /// Runs a command after loading scoob configuration into the environment
+    /// Runs a command after loading scoob secrets into the environment
     Start(Start),
 }
 
@@ -62,9 +32,9 @@ fn main() {
     let cli = Opt::from_args();
 
     let result = match &cli {
-        Opt::Modify(c) => modify(&c),
+        Opt::Manage(c) => manage(&c),
         Opt::Start(c) => {
-            let start_result = start(c);
+            let start_result = start(&c);
 
             match start_result {
                 Ok(status) => std::process::exit(status),

--- a/src/manage.rs
+++ b/src/manage.rs
@@ -1,7 +1,7 @@
 use crate::{Config, Encryption};
 use std::env;
-use structopt::StructOpt;
 use std::path::PathBuf;
+use structopt::StructOpt;
 
 enum Mode {
     Create,
@@ -28,8 +28,8 @@ pub fn manage(cmd: &Manage) -> Result<(), &'static str> {
             .is_empty()
     {
         return Err(
-			"You must define your $EDITOR environment variable to edit a Scoob configuration file.",
-		);
+            "You must define your $EDITOR environment variable to edit a Scoob configuration file.",
+        );
     }
 
     if cmd.create && cmd.edit {

--- a/src/manage.rs
+++ b/src/manage.rs
@@ -1,29 +1,40 @@
-use crate::{Config, ConfigFile, Encryption, Modify};
+use crate::{Config, Encryption};
 use colored::*;
 use std::env;
+use structopt::StructOpt;
+use std::path::PathBuf;
 
 enum Mode {
     Create,
     Edit,
 }
 
-pub fn modify(cmd: &Modify) -> Result<(), &'static str> {
+#[derive(Debug, StructOpt)]
+pub struct Manage {
+    /// Enforce editing of the configuration file. Scoob will error if the file does not exist
+    #[structopt(short, long)]
+    edit: bool,
+    /// Enforce creation of the configuration file. Scoob will error if the file already exists
+    #[structopt(short, long)]
+    create: bool,
+    /// Path to the scoob configuration file
+    #[structopt(parse(from_os_str))]
+    file: PathBuf,
+}
+
+pub fn manage(cmd: &Manage) -> Result<(), &'static str> {
     if env::var("EDITOR").is_err()
         || env::var("EDITOR")
             .unwrap_or_else(|_| "".to_string())
             .is_empty()
     {
         return Err(
-			"You must define your $EDITOR environment variable to modify a Scoob configuration file.",
+			"You must define your $EDITOR environment variable to edit a Scoob configuration file.",
 		);
     }
 
     if cmd.create && cmd.edit {
         return Err("Both '--edit' and '--create' flags cannot be provided");
-    }
-
-    if !cmd.create && !cmd.edit {
-        println!("{}", "Neither create nor edit mode was provided. Scoob will attempt to automatically determine the correct mode.".yellow());
     }
 
     if cmd.create && Config::exists(&cmd.file) {
@@ -55,7 +66,7 @@ pub fn modify(cmd: &Modify) -> Result<(), &'static str> {
         edit::Builder::new().suffix(".yml"),
     );
 
-    let new_config: ConfigFile = serde_yaml::from_str(&contents.unwrap()).unwrap();
+    let new_config: Config = serde_yaml::from_str(&contents.unwrap()).unwrap();
 
     let encrypted_config = encryption.encrypt_configuration(&new_config)?;
 

--- a/src/manage.rs
+++ b/src/manage.rs
@@ -1,5 +1,4 @@
 use crate::{Config, Encryption};
-use colored::*;
 use std::env;
 use structopt::StructOpt;
 use std::path::PathBuf;

--- a/src/start.rs
+++ b/src/start.rs
@@ -1,7 +1,25 @@
-use crate::{Config, Encryption, Start, SubCommand};
+use crate::{Config, Encryption};
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
+use std::path::PathBuf;
 use std::process::Command;
+use structopt::StructOpt;
+
+#[derive(Debug, PartialEq, StructOpt)]
+pub enum SubCommand {
+    #[structopt(external_subcommand)]
+    Other(Vec<String>),
+}
+
+#[derive(Debug, StructOpt)]
+pub struct Start {
+    /// Path to the scoob configuration file
+    #[structopt(parse(from_os_str))]
+    file: PathBuf,
+    /// The sub-command that you wish to run
+    #[structopt(subcommand)]
+    sub_command: SubCommand,
+}
 
 pub fn start(cmd: &Start) -> Result<i32, &'static str> {
     if !Config::exists(&cmd.file) {


### PR DESCRIPTION
@Emily As discussed, this renames `modify` to `manage`. I also removed the inferred options warning, since I think that's a fine way to use the CLI. 